### PR TITLE
Fix UnsupportedOperationException for non-approved beatmaps.

### DIFF
--- a/src/main/java/com/oopsjpeg/osu4j/OsuBeatmap.java
+++ b/src/main/java/com/oopsjpeg/osu4j/OsuBeatmap.java
@@ -45,7 +45,7 @@ public class OsuBeatmap extends OsuElement {
 	public OsuBeatmap(Osu api, JsonObject obj) {
 		super(api);
 		approved = ApprovalState.fromID(obj.get("approved").getAsInt());
-		approvedDate = Utility.parseDate(obj.get("approved_date").getAsString());
+		approvedDate = obj.get("approved_date").isJsonNull() ? null : Utility.parseDate(obj.get("approved_date").getAsString());
 		lastUpdate = Utility.parseDate(obj.get("last_update").getAsString());
 		artist = obj.get("artist").getAsString();
 		beatmapID = obj.get("beatmap_id").getAsInt();


### PR DESCRIPTION
Self-explanatory. osu!api returns JsonNull for approved_date of non-approved beatmaps.